### PR TITLE
Use file basename as target for s3 download

### DIFF
--- a/JenkinsJob.py
+++ b/JenkinsJob.py
@@ -1,4 +1,6 @@
 from __future__ import print_function
+from os import path
+
 import json
 import re
 import sys
@@ -128,7 +130,8 @@ def get_instance_metadata(instance_id):
 def get_config_file(metadata):
     config_file = 'config.ini'
     if 's3_config_file' in metadata.keys():
-        config_file = "/tmp/%s" % metadata['s3_config_file']
+        config_base_name = path.basename(metadata['s3_config_file'])
+        config_file = "/tmp/%s" % config_base_name
         s3_client.download_file(metadata['s3_bucket'],
                                 metadata['s3_config_file'],
                                 config_file)


### PR DESCRIPTION
To support multiple config files per environment in s3, I use keys with directories '/es/dev-int.ini'.  The s3 download fails because '/tmp/es/' dir doesn't exist.  Rather than create the directory in python, the basename is used to download directly to /tmp